### PR TITLE
fix(appraisals): pin concurrent-ruby to 1.3.4

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -5,6 +5,7 @@ appraise 'ruby-26.rails-60' do
   gem 'rspec-rails', '~> 5.0'
   gem 'factory_bot', '~> 6.2.0'
   gem 'google-protobuf', '< 3.24.0'
+  gem "concurrent-ruby", "1.3.4"
 end
 
 appraise 'ruby-26.rails-61' do
@@ -13,6 +14,7 @@ appraise 'ruby-26.rails-61' do
   gem 'rspec-rails', '~> 5.0'
   gem 'factory_bot', '~> 6.2.0'
   gem 'google-protobuf', '< 3.24.0'
+  gem "concurrent-ruby", "1.3.4"
 end
 
 # ruby 2.7
@@ -22,6 +24,7 @@ appraise 'ruby-27.rails-60' do
   gem 'factory_bot', '~> 6.2.0'
   gem 'google-cloud-pubsub', '~> 2.13.0'
   gem 'google-protobuf', '~> 3.24.0'
+  gem "concurrent-ruby", "1.3.4"
 end
 
 appraise 'ruby-27.rails-61' do
@@ -30,6 +33,7 @@ appraise 'ruby-27.rails-61' do
   gem 'factory_bot', '~> 6.2.0'
   gem 'google-cloud-pubsub', '~> 2.13.0'
   gem 'google-protobuf', '~> 3.24.0'
+  gem "concurrent-ruby", "1.3.4"
 end
 
 appraise 'ruby-27.rails-70' do
@@ -38,6 +42,7 @@ appraise 'ruby-27.rails-70' do
   gem 'factory_bot', '~> 6.2.0'
   gem 'google-cloud-pubsub', '~> 2.13.0'
   gem 'google-protobuf', '~> 3.24.0'
+  gem "concurrent-ruby", "1.3.4"
 end
 
 appraise 'ruby-27.rails-71' do
@@ -52,11 +57,13 @@ end
 appraise 'ruby-30.rails-61' do
   ruby '~> 3.0.0'
   gem 'rails', '~> 6.1.0'
+  gem "concurrent-ruby", "1.3.4"
 end
 
 appraise 'ruby-30.rails-70' do
   ruby '~> 3.0.0'
   gem 'rails', '~> 7.0.0'
+  gem "concurrent-ruby", "1.3.4"
 end
 
 appraise 'ruby-30.rails-71' do
@@ -68,11 +75,13 @@ end
 appraise 'ruby-31.rails-61' do
   ruby '~> 3.1.0'
   gem 'rails', '~> 6.1.0'
+  gem "concurrent-ruby", "1.3.4"
 end
 
 appraise 'ruby-31.rails-70' do
   ruby '~> 3.1.0'
   gem 'rails', '~> 7.0.0'
+  gem "concurrent-ruby", "1.3.4"
 end
 
 appraise 'ruby-31.rails-71' do

--- a/gemfiles/ruby_26.rails_60.gemfile
+++ b/gemfiles/ruby_26.rails_60.gemfile
@@ -14,5 +14,6 @@ gem "rubocop"
 gem "ruby-lsp"
 gem "rails", "~> 6.0.0"
 gem "google-protobuf", "< 3.24.0"
+gem "concurrent-ruby", "1.3.4"
 
 gemspec path: "../"

--- a/gemfiles/ruby_26.rails_61.gemfile
+++ b/gemfiles/ruby_26.rails_61.gemfile
@@ -14,5 +14,6 @@ gem "rubocop"
 gem "ruby-lsp"
 gem "rails", "~> 6.1.0"
 gem "google-protobuf", "< 3.24.0"
+gem "concurrent-ruby", "1.3.4"
 
 gemspec path: "../"

--- a/gemfiles/ruby_27.rails_60.gemfile
+++ b/gemfiles/ruby_27.rails_60.gemfile
@@ -15,5 +15,6 @@ gem "ruby-lsp"
 gem "rails", "~> 6.0.0"
 gem "google-cloud-pubsub", "~> 2.13.0"
 gem "google-protobuf", "~> 3.24.0"
+gem "concurrent-ruby", "1.3.4"
 
 gemspec path: "../"

--- a/gemfiles/ruby_27.rails_61.gemfile
+++ b/gemfiles/ruby_27.rails_61.gemfile
@@ -15,5 +15,6 @@ gem "ruby-lsp"
 gem "rails", "~> 6.1.0"
 gem "google-cloud-pubsub", "~> 2.13.0"
 gem "google-protobuf", "~> 3.24.0"
+gem "concurrent-ruby", "1.3.4"
 
 gemspec path: "../"

--- a/gemfiles/ruby_27.rails_70.gemfile
+++ b/gemfiles/ruby_27.rails_70.gemfile
@@ -15,5 +15,6 @@ gem "ruby-lsp"
 gem "rails", "~> 7.0.0"
 gem "google-cloud-pubsub", "~> 2.13.0"
 gem "google-protobuf", "~> 3.24.0"
+gem "concurrent-ruby", "1.3.4"
 
 gemspec path: "../"

--- a/gemfiles/ruby_30.rails_61.gemfile
+++ b/gemfiles/ruby_30.rails_61.gemfile
@@ -13,5 +13,6 @@ gem "pry-byebug"
 gem "rubocop"
 gem "ruby-lsp"
 gem "rails", "~> 6.1.0"
+gem "concurrent-ruby", "1.3.4"
 
 gemspec path: "../"

--- a/gemfiles/ruby_30.rails_70.gemfile
+++ b/gemfiles/ruby_30.rails_70.gemfile
@@ -13,5 +13,6 @@ gem "pry-byebug"
 gem "rubocop"
 gem "ruby-lsp"
 gem "rails", "~> 7.0.0"
+gem "concurrent-ruby", "1.3.4"
 
 gemspec path: "../"

--- a/gemfiles/ruby_31.rails_61.gemfile
+++ b/gemfiles/ruby_31.rails_61.gemfile
@@ -13,5 +13,6 @@ gem "pry-byebug"
 gem "rubocop"
 gem "ruby-lsp"
 gem "rails", "~> 6.1.0"
+gem "concurrent-ruby", "1.3.4"
 
 gemspec path: "../"

--- a/gemfiles/ruby_31.rails_70.gemfile
+++ b/gemfiles/ruby_31.rails_70.gemfile
@@ -13,5 +13,6 @@ gem "pry-byebug"
 gem "rubocop"
 gem "ruby-lsp"
 gem "rails", "~> 7.0.0"
+gem "concurrent-ruby", "1.3.4"
 
 gemspec path: "../"


### PR DESCRIPTION
Pinned the concurrent-ruby gem to version 1.3.4 in the Appraisals file to resolve an error with version 1.3.5: uninitialized constant ActiveSupport::LoggerThreadSafeLevel::Logger (NameError).